### PR TITLE
Resolve #165: Support different install path from the bundle installer

### DIFF
--- a/Hourglass.Bundle/Bundle.wxs
+++ b/Hourglass.Bundle/Bundle.wxs
@@ -1,13 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
      xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
-    <Bundle Name="Hourglass" Version="1.9.0.0" Manufacturer="Chris Dziemborowicz" UpgradeCode="f1d002c9-cfc9-40fb-84af-96e7aec26e0b" IconSourceFile="$(var.Hourglass.ProjectDir)Resources\AppIcon.ico">
-        <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense">
-            <bal:WixStandardBootstrapperApplication LicenseFile="MIT.rtf" LogoFile="Logo.png"/>
-        </BootstrapperApplicationRef>
-        <Chain>
-            <PackageGroupRef Id="NetFx40ClientWeb"/>
-            <MsiPackage Id="HourglassSetup" SourceFile="$(var.Hourglass.Setup.TargetPath)"/>
-        </Chain>
-    </Bundle>
+  <Bundle Name="Hourglass"
+          Version="1.9.0.0"
+          Manufacturer="Chris Dziemborowicz"
+          UpgradeCode="f1d002c9-cfc9-40fb-84af-96e7aec26e0b"
+          IconSourceFile="$(var.Hourglass.ProjectDir)Resources\AppIcon.ico">
+
+    <!-- Specify a "sensible default" install location -->
+    <Variable Name="InstallFolder" Type="string" Value="[ProgramFilesFolder]Hourglass" />
+
+    <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense">
+      <bal:WixStandardBootstrapperApplication LicenseFile="MIT.rtf" LogoFile="Logo.png" />
+    </BootstrapperApplicationRef>
+    <Chain>
+      <PackageGroupRef Id="NetFx40ClientWeb" />
+      <MsiPackage Id="HourglassSetup" SourceFile="$(var.Hourglass.Setup.TargetPath)">
+        <!-- Pass this selection down to the Hourglass.Setup msi -->
+        <MsiProperty Name="APPLICATIONFOLDER" Value="[InstallFolder]" />
+      </MsiPackage>
+    </Chain>
+  </Bundle>
 </Wix>


### PR DESCRIPTION
There are actually 2 changes in Bundle here:

1. Added a default path, it's probalby not the most elegant solution, there's gotta be a way to grab that  path from the child Setup msi, but I don't know how.
2. Passing that path from Budle to the Setup msi. If I recall, it's documented in WiX that  `InstallFolder` is a pre-cooked variable for WiX Burn.