### PR TITLE
added option for titleless window

### DIFF
--- a/Hourglass/CommandLineArguments.cs
+++ b/Hourglass/CommandLineArguments.cs
@@ -866,6 +866,9 @@ namespace Hourglass
 
             switch (value.ToLowerInvariant())
             {
+                case "none":
+                    return WindowTitleMode.None;
+
                 case "app":
                     return WindowTitleMode.ApplicationName;
 

--- a/Hourglass/Properties/Resources.Designer.cs
+++ b/Hourglass/Properties/Resources.Designer.cs
@@ -305,6 +305,15 @@ namespace Hourglass.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _None.
+        /// </summary>
+        internal static string ContextMenuNoWindowTitleMenuItem {
+            get {
+                return ResourceManager.GetString("ContextMenuNoWindowTitleMenuItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Open all saved timers.
         /// </summary>
         internal static string ContextMenuOpenAllSavedTimersMenuItem {

--- a/Hourglass/Properties/Resources.resx
+++ b/Hourglass/Properties/Resources.resx
@@ -1181,6 +1181,10 @@ $</value>
     <value>Are you sure you want to delete the selected theme?</value>
     <comment>The prompt displayed when the user deletes a theme</comment>
   </data>
+  <data name="ContextMenuNoWindowTitleMenuItem" xml:space="preserve">
+    <value>_None</value>
+    <comment>The text for the application name menu item, where the character following the optional underscore (_) is the access key</comment>
+  </data>
   <data name="ContextMenuApplicationNameWindowTitleMenuItem" xml:space="preserve">
     <value>_Application name</value>
     <comment>The text for the application name menu item, where the character following the optional underscore (_) is the access key</comment>

--- a/Hourglass/Timing/TimerOptions.cs
+++ b/Hourglass/Timing/TimerOptions.cs
@@ -19,6 +19,11 @@ namespace Hourglass.Timing
     public enum WindowTitleMode
     {
         /// <summary>
+        /// Hides the timer window title bar.
+        /// </summary>
+        None,
+
+        /// <summary>
         /// The timer window title is set to show the application name.
         /// </summary>
         ApplicationName,

--- a/Hourglass/Windows/ContextMenu.cs
+++ b/Hourglass/Windows/ContextMenu.cs
@@ -177,6 +177,11 @@ namespace Hourglass.Windows
         private MenuItem windowTitleMenuItem;
 
         /// <summary>
+        /// The "None" window title <see cref="MenuItem"/>.
+        /// </summary>
+        private MenuItem noWindowTitleMenuItem;
+
+        /// <summary>
         /// The "Application name" window title <see cref="MenuItem"/>.
         /// </summary>
         private MenuItem applicationNameWindowTitleMenuItem;
@@ -668,6 +673,16 @@ namespace Hourglass.Windows
             this.windowTitleMenuItem = new MenuItem();
             this.windowTitleMenuItem.Header = Properties.Resources.ContextMenuWindowTitleMenuItem;
             this.advancedOptionsMenuItem.Items.Add(this.windowTitleMenuItem);
+
+            // No window title
+            this.noWindowTitleMenuItem = new MenuItem();
+            this.noWindowTitleMenuItem.Header = Properties.Resources.ContextMenuNoWindowTitleMenuItem;
+            this.noWindowTitleMenuItem.IsCheckable = true;
+            this.noWindowTitleMenuItem.Tag = WindowTitleMode.None;
+            this.noWindowTitleMenuItem.Click += this.WindowTitleMenuItemClick;
+            this.noWindowTitleMenuItem.Click += this.CheckableMenuItemClick;
+            this.windowTitleMenuItem.Items.Add(this.noWindowTitleMenuItem);
+            this.selectableWindowTitleMenuItems.Add(this.noWindowTitleMenuItem);
 
             // Application name (window title)
             this.applicationNameWindowTitleMenuItem = new MenuItem();

--- a/Hourglass/Windows/TimerWindow.xaml
+++ b/Hourglass/Windows/TimerWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Hourglass.Windows"
         Width="350" Height="150" MinWidth="250" MinHeight="150"
+        ResizeMode="CanResize"
         Loaded="WindowLoaded" StateChanged="WindowStateChanged" Closing="WindowClosing"
         MouseDown="WindowMouseDown" MouseDoubleClick="WindowMouseDoubleClick">
     <Window.CommandBindings>

--- a/Hourglass/Windows/TimerWindow.xaml.cs
+++ b/Hourglass/Windows/TimerWindow.xaml.cs
@@ -364,17 +364,16 @@ namespace Hourglass.Windows
                 }
 
                 this.isFullScreen = value;
+                this.WindowStyle = GetWindowStyle();
 
                 if (this.isFullScreen)
                 {
-                    this.WindowStyle = WindowStyle.None;
                     this.WindowState = WindowState.Normal; // Needed to put the window on top of the taskbar
                     this.WindowState = WindowState.Maximized;
                     this.ResizeMode = ResizeMode.NoResize;
                 }
                 else
                 {
-                    this.WindowStyle = WindowStyle.SingleBorderWindow;
                     this.WindowState = this.restoreWindowState;
                     this.ResizeMode = ResizeMode.CanResize;
                 }
@@ -1114,7 +1113,7 @@ namespace Hourglass.Windows
         {
             this.InnerGrid.Background = this.Theme.BackgroundBrush;
             this.ProgressBar.Foreground = this.Theme.ProgressBarBrush;
-            this.ProgressBar.Background  = this.Theme.ProgressBackgroundBrush;
+            this.ProgressBar.Background = this.Theme.ProgressBackgroundBrush;
             this.InnerNotificationBorder.BorderBrush = this.Theme.ExpirationFlashBrush;
             this.OuterNotificationBorder.Background = this.Theme.ExpirationFlashBrush;
             this.TimerTextBox.Foreground = this.Theme.PrimaryTextBrush;
@@ -1200,6 +1199,16 @@ namespace Hourglass.Windows
             }
         }
 
+        private WindowStyle GetWindowStyle()
+        {
+            if (this.Options.WindowTitleMode == WindowTitleMode.None || this.isFullScreen)
+            {
+                return WindowStyle.None;
+            }
+
+            return WindowStyle.SingleBorderWindow;
+        }
+
         /// <summary>
         /// Updates the window title.
         /// </summary>
@@ -1207,6 +1216,9 @@ namespace Hourglass.Windows
         {
             switch (this.Options.WindowTitleMode)
             {
+                case WindowTitleMode.None:
+                    break;
+
                 case WindowTitleMode.ApplicationName:
                     this.Title = Properties.Resources.TimerWindowTitle;
                     break;
@@ -1321,6 +1333,8 @@ namespace Hourglass.Windows
 
                     break;
             }
+
+            this.WindowStyle = GetWindowStyle();
         }
 
         /// <summary>
@@ -1823,6 +1837,11 @@ namespace Hourglass.Windows
         /// <param name="e">The event data.</param>
         private void WindowMouseDown(object sender, MouseButtonEventArgs e)
         {
+            if (e.ChangedButton == MouseButton.Left)
+            {
+                this.DragMove();
+            }
+
             if (e.OriginalSource is Panel)
             {
                 this.CancelOrReset();


### PR DESCRIPTION
I wanted a more compact view for the hourglass window - so I removed the title bar.

- The title bar can now be toggled off or on via the *Advanced options &rarr; Windows title &rarr; **None***
![image](https://user-images.githubusercontent.com/7921024/52170335-783e7b00-2748-11e9-84c3-f573c4a4eb01.png)
- The title-less window can be moved and resized via mouse (is draggable).
![image](https://user-images.githubusercontent.com/7921024/52170351-c784ab80-2748-11e9-930f-e98e340a2b1a.png)


