### PR TITLE
using inverted progress bar for if showing time left instead of time …

### DIFF
--- a/Hourglass/Windows/TimerWindow.xaml.cs
+++ b/Hourglass/Windows/TimerWindow.xaml.cs
@@ -1014,6 +1014,18 @@ namespace Hourglass.Windows
             this.UpdateBoundControls();
         }
 
+        private double GetTimerProgress()
+        {
+            if (this.Options.ShowTimeElapsed)
+            {
+                return this.Timer.TimeLeftAsPercentage ?? 0.0;
+            }
+            else
+            {
+                return this.Timer.TimeElapsedAsPercentage ?? 100.0;
+            }
+        }
+
         /// <summary>
         /// Updates the controls bound to timer properties.
         /// </summary>
@@ -1022,7 +1034,7 @@ namespace Hourglass.Windows
             switch (this.Mode)
             {
                 case TimerWindowMode.Input:
-                    this.ProgressBar.Value = this.Timer.TimeLeftAsPercentage ?? 0.0;
+                    this.ProgressBar.Value = GetTimerProgress();
                     this.UpdateTaskbarProgress();
 
                     // Enable and disable command buttons as required
@@ -1054,7 +1066,7 @@ namespace Hourglass.Windows
                     this.TimerTextBox.Text = this.Timer.Options.ShowTimeElapsed
                         ? this.Timer.TimeElapsedAsString
                         : this.Timer.TimeLeftAsString;
-                    this.ProgressBar.Value = this.Timer.TimeLeftAsPercentage ?? 0.0;
+                    this.ProgressBar.Value = GetTimerProgress();
                     this.UpdateTaskbarProgress();
 
                     if (this.Options.LockInterface)


### PR DESCRIPTION
This PR invertes the direction of the progress bar so that

- progress is from 0..100 when displaying *time elapsed*
- progress is from 100..0 when displaying *time left*

![image](https://user-images.githubusercontent.com/7921024/52182911-b7310700-2802-11e9-84fd-f977d3a260c4.png)

However, it does not (yet) change the progress of the task bar icon..